### PR TITLE
Board 엔티티에 like count 추가

### DIFF
--- a/src/main/java/com/project/numble/application/board/domain/Board.java
+++ b/src/main/java/com/project/numble/application/board/domain/Board.java
@@ -50,6 +50,9 @@ public class Board extends BaseTimeEntity {
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Like> likes = new HashSet<>();
 
+    @Column(name = "like_count")
+    private Integer likeCount = 0;
+
     @Builder
     private Board(User user, String content, String boardAddress, List<Image> images, String categoryType, List<BoardAnimal> boardAnimals) {
         this.user = user;
@@ -57,6 +60,7 @@ public class Board extends BaseTimeEntity {
         this.boardAddress = boardAddress;
         this.images = images;
         this.categoryType = categoryType;
+        this.likeCount = getLikeCount();
         this.boardAnimals = boardAnimals;
     }
 
@@ -76,6 +80,14 @@ public class Board extends BaseTimeEntity {
     // 조회수 + 1
     public int addViewCount(Board board) {
         return board.getViewCount() + 1;
+    }
+
+
+    public void plusLikeCount() {
+        this.likeCount = this.getLikeCount() + 1;
+    }
+    public void minusLikeCount() {
+        this.likeCount = this.getLikeCount() - 1;
     }
 
     public void addLike(Like like){

--- a/src/main/java/com/project/numble/application/board/dto/response/GetAllBoardResponse.java
+++ b/src/main/java/com/project/numble/application/board/dto/response/GetAllBoardResponse.java
@@ -3,6 +3,7 @@ package com.project.numble.application.board.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.project.numble.application.board.domain.Board;
 import com.project.numble.application.board.domain.Image;
+import com.project.numble.application.board.domain.Like;
 import com.project.numble.application.user.domain.Animal;
 import com.project.numble.application.user.domain.enums.AnimalType;
 import lombok.Getter;
@@ -54,7 +55,7 @@ public class GetAllBoardResponse {
         this.createdDate = board.getCreatedDate();
         this.boardAnimalTypes = board.getBoardAnimals().stream().map(animal -> AnimalType.getName(animal.getAnimalType())).collect(
                 Collectors.toList());
-        this.likeCount = board.getLikes().size();
+        this.likeCount = board.getLikeCount();
         this.lastModifiedDate = board.getLastModifiedDate();
     }
 

--- a/src/main/java/com/project/numble/application/board/dto/response/GetBoardResponse.java
+++ b/src/main/java/com/project/numble/application/board/dto/response/GetBoardResponse.java
@@ -58,7 +58,7 @@ public class GetBoardResponse {
         this.comments = board.getComments().stream().map(GetCommentResponse::new).collect(Collectors.toList());
         this.boardAnimalTypes = board.getBoardAnimals().stream().map(animal -> AnimalType.getName(animal.getAnimalType())).collect(
                 Collectors.toList());
-        this.likeCount = board.getLikes().size();
+        this.likeCount = board.getLikeCount();
         this.createdDate = board.getCreatedDate();
         this.lastModifiedDate = board.getLastModifiedDate();
     }

--- a/src/main/java/com/project/numble/application/board/service/StandardBoardService.java
+++ b/src/main/java/com/project/numble/application/board/service/StandardBoardService.java
@@ -2,6 +2,7 @@ package com.project.numble.application.board.service;
 
 import com.project.numble.application.board.domain.Board;
 import com.project.numble.application.board.domain.BoardAnimal;
+import com.project.numble.application.board.domain.Like;
 import com.project.numble.application.board.dto.request.AddBoardRequest;
 import com.project.numble.application.board.dto.request.ModBoardRequest;
 import com.project.numble.application.board.dto.response.GetAllBoardResponse;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,7 +35,7 @@ public class StandardBoardService implements BoardService{
 
     private final UserRepository userRepository;
 
-    private final LikeService likeService;
+    private final LikeRepository likeRepository;
 
     // 저장
     @Override
@@ -66,7 +68,7 @@ public class StandardBoardService implements BoardService{
     public GetBoardResponse getBoard(Long userId, Long boardId) {
         Board board = getBoardOne(boardId);
         GetBoardResponse getBoardResponse = new GetBoardResponse(board);
-        getBoardResponse.setLikeCheck(!likeService.isNotAlreadyLike(userId, boardId));
+        getBoardResponse.setLikeCheck(!likeRepository.findByUserIdAndBoardId(userId, boardId).isEmpty());
         return getBoardResponse;
     }
 
@@ -77,7 +79,7 @@ public class StandardBoardService implements BoardService{
     public List<GetAllBoardResponse> getBoardUser(Long userId) {
         List<GetAllBoardResponse> getAllBoardResponses = boardRepository.findAllByUserId(userId).stream().map(GetAllBoardResponse::new).collect(Collectors.toList());
         for (GetAllBoardResponse getAllBoardResponse : getAllBoardResponses) {
-            getAllBoardResponse.setLikeCheck(!likeService.isNotAlreadyLike(userId, getAllBoardResponse.getBoardId()));
+            getAllBoardResponse.setLikeCheck(!likeRepository.findByUserIdAndBoardId(userId, getAllBoardResponse.getBoardId()).isEmpty());
         }
         return getAllBoardResponses;
     }
@@ -88,7 +90,7 @@ public class StandardBoardService implements BoardService{
     public List<GetAllBoardResponse> getBoardList(Long userId) {
         List<GetAllBoardResponse> getAllBoardResponses = boardRepository.findAllByOrderByCreatedDateDesc().stream().map(GetAllBoardResponse::new).collect(Collectors.toList());
         for (GetAllBoardResponse getAllBoardResponse : getAllBoardResponses) {
-            getAllBoardResponse.setLikeCheck(!likeService.isNotAlreadyLike(userId, getAllBoardResponse.getBoardId()));
+            getAllBoardResponse.setLikeCheck(!likeRepository.findByUserIdAndBoardId(userId, getAllBoardResponse.getBoardId()).isEmpty());
         }
         return getAllBoardResponses;
     }

--- a/src/main/java/com/project/numble/application/board/service/StandardLikeService.java
+++ b/src/main/java/com/project/numble/application/board/service/StandardLikeService.java
@@ -35,6 +35,7 @@ public class StandardLikeService implements LikeService{
         if (isNotAlreadyLike(userId, boardId)) {
             likeRepository.save(like);
             board.addLike(like);
+            board.plusLikeCount();
             return;
         }
 
@@ -46,6 +47,7 @@ public class StandardLikeService implements LikeService{
         Like like = likeRepository.findByUserIdAndBoardId(userId, boardId).orElseThrow(() -> new LikeNotExistsException());
         Board board = boardRepository.findById(boardId).orElseThrow(() -> new BoardNotExistsException());
         likeRepository.delete(like);
+        board.minusLikeCount();
         board.delLike(like);
     }
 


### PR DESCRIPTION
### 💡 개요
 - Board 엔티티에 like count 추가

### 📑 작업 사항
 - Board 엔티티에 like count 추가
 - LikeService에 plusLikeCount 부분 추가

### ✒️ 코드 리뷰 요청 사항
게시글 전체 조회 시 회원이 해당 게시글에 좋아요를 눌렀는지에 대해 판단을 하는 방식에 대한 구현 방법이 궁금합니다. 
지금은 하나의 게시글마다 각각 좋아요를 눌렀는지를 쿼리를 날리는 식으로 되어있는데 다른 개선 방식에 대해 첨언 부탁드립니다!
(해당 내용은 이전 pr에 올라와 있습니다. StandardBoardService -> getBoardUser, getBoardList 메서드 부분입니다.)